### PR TITLE
fix workbox opts code example

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -94,9 +94,10 @@ module.exports = withOffline({
         handler: 'networkFirst',
         options: {
           cacheableResponse: {
-          statuses: [0, 200],
-          headers: {
-            'x-test': 'true'
+            statuses: [0, 200],
+            headers: {
+              'x-test': 'true'
+            }
           }
         }
       }


### PR DESCRIPTION
the example was missing an extra `}`