### PR TITLE
Update next version

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "sw-helpers"
   ],
   "peerDependencies": {
-    "next": "~5.0.0",
+    "next": "~5.1.0",
     "react": "~16.2.0"
   },
   "dependencies": {


### PR DESCRIPTION
When I upgrade next to 5.1.0, I get this waring

```
warning " > next-offline@2.2.0" has incorrect peer dependency "next@~5.0.0".
```

If allow all version after 5.0.0, `^5.0.0` is a method.