### PR TITLE
Enable InjectManifest with `generateSw` option

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,5 @@
 const SwGen = require('./plugin')
-const { GenerateSW } = require('workbox-webpack-plugin')
+const { GenerateSW, InjectManifest } = require('workbox-webpack-plugin')
 const path = require('path')
 
 module.exports = (nextConfig = {}) => ({
@@ -16,6 +16,7 @@ module.exports = (nextConfig = {}) => ({
     if (options.dev) return config
 
     const {
+      generateSw = true,
       dontAutoRegisterSw = false,
       workboxOpts = {
         runtimeCaching: [
@@ -26,7 +27,9 @@ module.exports = (nextConfig = {}) => ({
 
     config.plugins = [
       ...config.plugins,
-      new GenerateSW({ ...workboxOpts }),
+      generateSw
+        ? new GenerateSW({ ...workboxOpts })
+        : new InjectManifest({ ...workboxOpts }),
       new SwGen({ buildId: options.buildId })
     ]
 

--- a/plugin.js
+++ b/plugin.js
@@ -22,10 +22,14 @@ module.exports = class NextFilePrecacherPlugin {
       const manifest = await nextFiles(this.opts.buildId)
       const genSw = await fs.readFile(join(this.opts.outputPath, 'service-worker.js'), 'utf8')
 
+      const multipleImportRegex = /"precache-manifest\.(.*?)\.js",\s/
+
       const newSw =
-        `self.__precacheManifest = ${JSON.stringify(manifest.precaches, null, 2)}`
-        + '\n'
-        + genSw.replace(genSw.match(/"precache-manifest.*/)[0], '')
+        `self.__precacheManifest = ${JSON.stringify(manifest.precaches)}\n${
+          multipleImportRegex.test(genSw)
+            ? genSw.replace(genSw.match(multipleImportRegex)[0], '')
+            : genSw.replace(genSw.match(/"precache-manifest.*/)[0], '')
+        }`
 
       return await fs.writeFile(this.opts.filename, newSw, 'utf8')
     }, err => {


### PR DESCRIPTION
If generateSw option is false we use InjectManifest instead
Catch the case where importScripts has multiple parameters instead of only the `precache-manifest.<hash>.js`, allowing to have custom `service-worker.js` file with InjectManifest option

Closes #14 
