### PR TITLE
Allow next build directory to be set

### DIFF
--- a/next-files.js
+++ b/next-files.js
@@ -35,10 +35,10 @@ function getChunks (app) {
   })
 }
 
-module.exports = async function Precache (id) {
+module.exports = async function Precache ({ buildId, nextDir }) {
   const app = {
-    buildId: id,
-    nextDir: resolve(join('./', '.next')),
+    buildId,
+    nextDir,
     precaches: []
   }
 

--- a/plugin.js
+++ b/plugin.js
@@ -19,7 +19,10 @@ module.exports = class NextFilePrecacherPlugin {
     })
 
     compiler.plugin('done', async () => {
-      const manifest = await nextFiles(this.opts.buildId)
+      const manifest = await nextFiles({
+        buildId: this.opts.buildId,
+        nextDir: this.opts.outputPath
+      })
       const genSw = await fs.readFile(join(this.opts.outputPath, 'service-worker.js'), 'utf8')
 
       const multipleImportRegex = /"precache-manifest\.(.*?)\.js",\s/


### PR DESCRIPTION
This was making an assumption that the build directory will be `.next`.
This can be modified by calling `next build [dir]`. Update the plugin to
respect the directory passed into the build command.