### PR TITLE
Allow `assetPrefix` to be set

### DIFF
--- a/index.js
+++ b/index.js
@@ -30,7 +30,7 @@ module.exports = (nextConfig = {}) => ({
       generateSw
         ? new GenerateSW({ ...workboxOpts })
         : new InjectManifest({ ...workboxOpts }),
-      new SwGen({ buildId: options.buildId })
+      new SwGen({ buildId: options.buildId, assetPrefix: options.config.assetPrefix })
     ]
 
     const originalEntry = config.entry

--- a/next-files.js
+++ b/next-files.js
@@ -35,10 +35,10 @@ function getChunks (app) {
   })
 }
 
-module.exports = async function Precache (id) {
+module.exports = async function Precache ({ buildId, nextDir }) {
   const app = {
-    buildId: id,
-    nextDir: resolve(join('./', '.next')),
+    buildId,
+    nextDir,
     precaches: []
   }
 

--- a/next-files.js
+++ b/next-files.js
@@ -10,7 +10,7 @@ function getBundles (app) {
 
       app.precaches = [
         ...app.precaches,
-        ...createPaths(files, bundle, app.buildId)
+        ...createPaths(files, bundle, app.buildId, app.assetPrefix)
       ]
 
       done(app)
@@ -27,7 +27,7 @@ function getChunks (app) {
 
       app.precaches = [
         ...app.precaches,
-        ...createPaths(files, chunkDir, app.buildId)
+        ...createPaths(files, chunkDir, app.buildId, app.assetPrefix)
       ]
 
       done(app)
@@ -35,10 +35,11 @@ function getChunks (app) {
   })
 }
 
-module.exports = async function Precache ({ buildId, nextDir }) {
+module.exports = async function Precache ({ buildId, nextDir, assetPrefix }) {
   const app = {
     buildId,
     nextDir,
+    assetPrefix,
     precaches: []
   }
 
@@ -57,6 +58,7 @@ function getDirectories (id) {
   }
 }
 
-function createPaths (files, path, id) {
-  return files.filter(hasJs).map(file => ({url: join(path, file), revision: id}))
+function createPaths (files, path, id, assetPrefix) {
+  const prefix = assetPrefix || ''
+  return files.filter(hasJs).map(file => ({url: `${prefix}${join(path, file)}`, revision: id}))
 }

--- a/plugin.js
+++ b/plugin.js
@@ -21,7 +21,8 @@ module.exports = class NextFilePrecacherPlugin {
     compiler.plugin('done', async () => {
       const manifest = await nextFiles({
         buildId: this.opts.buildId,
-        nextDir: this.opts.outputPath
+        nextDir: this.opts.outputPath,
+        assetPrefix: this.opts.assetPrefix
       })
       const genSw = await fs.readFile(join(this.opts.outputPath, 'service-worker.js'), 'utf8')
 

--- a/plugin.js
+++ b/plugin.js
@@ -19,7 +19,10 @@ module.exports = class NextFilePrecacherPlugin {
     })
 
     compiler.plugin('done', async () => {
-      const manifest = await nextFiles(this.opts.buildId)
+      const manifest = await nextFiles({
+        buildId: this.opts.buildId,
+        nextDir: this.opts.outputPath
+      })
       const genSw = await fs.readFile(join(this.opts.outputPath, 'service-worker.js'), 'utf8')
 
       const multipleImportRegex = /"precache-manifest\.(.*?)\.js",\s/


### PR DESCRIPTION
This builds on https://github.com/hanford/next-offline/pull/17

If there is an asset prefix set in the next config then we should respect 
that when generating the manifest. This passes the asset prefix down 
and then uses that if it's available.