### PR TITLE
fix: bundle path

### DIFF
--- a/next-files.js
+++ b/next-files.js
@@ -54,7 +54,7 @@ const hasJs = file => /\.js$/.test(file)
 function getDirectories (id) {
   return {
     chunk: '/_next/webpack/chunks',
-    bundle: `/_next/${id}/page`
+    bundle: `_next/${id}/page`
   }
 }
 


### PR DESCRIPTION
## Overview

When build, path is like this:
```
//_next/dc99e9ee-d706-467f-b692-051d48adecaa/page/_app.js
```

This is not working when see with localhost like this.
![screen shot 2018-06-13 at 19 14 57](https://user-images.githubusercontent.com/4067007/41345258-1a9da038-6f3e-11e8-9821-ad39bebe285b.png)

I do not know if this is correct.
