### PR TITLE
fix: prefix path

### DIFF
--- a/next-files.js
+++ b/next-files.js
@@ -58,7 +58,7 @@ function getDirectories (id) {
   }
 }
 
-function createPaths (files, path, id, assetPrefix) {
-  const prefix = assetPrefix || ''
+function createPaths (files, path, id, assetPrefix = '') {
+  const prefix = assetPrefix === '/' ? '' : assetPrefix;
   return files.filter(hasJs).map(file => ({url: `${prefix}${join(path, file)}`, revision: id}))
 }


### PR DESCRIPTION
## Overview

```js
// my next.config.js
assetPrefix: '/'
```

When build, path is like this:
```
//_next/dc99e9ee-d706-467f-b692-051d48adecaa/page/_app.js
```

This is not working like this.
![screen shot 2018-06-13 at 19 14 57](https://user-images.githubusercontent.com/4067007/41349080-b0f27cce-6f49-11e8-9f6d-7101d07fd352.png)

I do not know if this is correct.
