### PR TITLE
Use the dir and output dir that next is given

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
   },
   "dependencies": {
     "fs-extra": "~5.0.0",
+    "minimist": "1.2.0",
     "webpack": "~3.11.0",
     "workbox-build": "~3.2.0",
     "workbox-webpack-plugin": "~3.2.0"


### PR DESCRIPTION
If you parse arguments into the `next export` command it would be good
if those arguments were used by `next-offline` rather than getting you
to set them again.

This reads in the `dir` and `outputDir` in the same way as the
`next-export`. Previously if you used a custom `dir` this plugin
wouldn't have worked as there was no way of telling it where your
application directory was so when it tried to locate the `BUILD_ID` it
would all break.

This fixes https://github.com/hanford/next-offline/issues/24