### PR TITLE
Remove React as peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,8 +36,7 @@
     "sw-helpers"
   ],
   "peerDependencies": {
-    "next": "^5.0.0 || ^6.0.0",
-    "react": "^16.2.0"
+    "next": "^5.0.0 || ^6.0.0"
   },
   "dependencies": {
     "fs-extra": "~5.0.0",


### PR DESCRIPTION
Since this module doesn't depend on anything from React, I thought it best to remove the peer dependency since that is covered by Next. This way there's no mismatch between the React versions of this plugin and Next's peerDep on React.