### PR TITLE
Skip exporting in development.

### DIFF
--- a/export.js
+++ b/export.js
@@ -1,9 +1,10 @@
-const path = require('path')
 const { readFile, writeFile } = require('fs-extra')
 const Precache = require('./next-files')
 const { generateSW, injectManifest } = require('workbox-build')
 const { join } = require('path')
 const parseArgs = require('minimist')
+
+const dev = process.env.NODE_ENV !== 'production'
 
 module.exports = Export
 
@@ -18,7 +19,7 @@ async function Export (nextConfig) {
     }
   } = nextConfig
 
-  if (typeof exportPathMap !== 'function') {
+  if (dev || typeof exportPathMap !== 'function') {
     return {}
   }
 


### PR DESCRIPTION
For some reason `exportPathMap` is called on development as well which is looking for build assets that don't exist. Given that `export` can only be run after `build` (Next.js itself throws) it's safe to assume that on prod exports the `.next/BUILD_ID` file will exist and skip the sw generation entirely for dev exports.

Next.js always sets `process.env.NODE_ENV` to production except for `next dev` command:
https://github.com/zeit/next.js/blob/canary/bin/next#L62

Fixes #31 