### PR TITLE
Include webpack static files.

### DIFF
--- a/plugin.js
+++ b/plugin.js
@@ -19,7 +19,7 @@ module.exports = class NextFilePrecacherPlugin {
     })
 
     compiler.plugin('done', async () => {
-      const manifest = await nextFiles({
+      const precacheFiles = await nextFiles({
         buildId: this.opts.buildId,
         nextDir: this.opts.outputPath,
         assetPrefix: this.opts.assetPrefix
@@ -29,7 +29,7 @@ module.exports = class NextFilePrecacherPlugin {
       const multipleImportRegex = /"precache-manifest\.(.*?)\.js",\s/
 
       const newSw =
-        `self.__precacheManifest = ${JSON.stringify(manifest.precaches)}\n${
+        `self.__precacheManifest = ${JSON.stringify(precacheFiles, null, 2)};\n\n${
           multipleImportRegex.test(genSw)
             ? genSw.replace(genSw.match(multipleImportRegex)[0], '')
             : genSw.replace(genSw.match(/"precache-manifest.*/)[0], '')


### PR DESCRIPTION
* Include webpack generated static files (e.g. `.next/static/commons/main.js`, `.next/static/style.css`)
* Better formatting of precache array (indented)
* Refactor

However, I believe there's a better way of doing this as the workbox generated precache manifest contains all the Next.js emitted assets. We should be reading that file, looping through all of those files and simply remapping the url with the new `buildId` revision.

Any reason why we shouldn't do that? If you agree I can do it.