### PR TITLE
Precache user-defined static files.

### DIFF
--- a/index.js
+++ b/index.js
@@ -24,6 +24,8 @@ module.exports = (nextConfig = {}) => ({
       generateSw = true,
       dontAutoRegisterSw = false,
       workboxOpts = {
+        globPatterns: ['static/**/*'],
+        globDirectory: '.',
         runtimeCaching: [
           { urlPattern: /^https?.*/, handler: 'networkFirst' }
         ]

--- a/readme.md
+++ b/readme.md
@@ -122,6 +122,21 @@ if ('serviceWorker' in navigator) {
 
 This behavior can be disabled by passing in `dontAutoRegisterSw: true` to top level config object.
 
+By default `next-offline` will precache all the Next.js webpack emitted files and the user-defined static ones (inside `/static`) - essentially everything that is exported as well.
+
+If you'd like to include some more or change the origin of your static files use the given workbox options:
+
+```js
+workboxOpts: {
+  globPatterns: ['app/static/**/*', 'any/other/fileglob/to/cache'],
+  globDirectory: '.',
+  modifyUrlPrefix: {
+    'app': assetPrefix,
+  },
+  runtimeCaching: {...}
+}
+```
+
 
 #### next export
 If you're using `next export` you'll need to specify an [exportPathMap function](https://github.com/zeit/next.js#static-html-export)


### PR DESCRIPTION
* Precache `/static` files - they are also exported
* Add instructions on how to do that if your app is inside a custom folder