### PR TITLE
Fix manifest import regex for injecting.

### DIFF
--- a/index.js
+++ b/index.js
@@ -40,7 +40,6 @@ module.exports = (nextConfig = {}) => ({
         new InlineNextPrecacheManifestPlugin({
           outputPath: config.output.path,
           urlPrefix: assetPrefix,
-          manifestDest: 'precache-manifest.*.js',
           swDest: workboxOpts.swDest || 'service-worker.js',
         }),
       );


### PR DESCRIPTION
Update replace regex to accommodate all different usages specified in https://github.com/hanford/next-offline/issues/60#issuecomment-427045410, including injecting with additional scripts.

Fixes #60