### PR TITLE
Add `async` to webpack function

### DIFF
--- a/index.js
+++ b/index.js
@@ -9,7 +9,7 @@ const exportSw = require('./export');
 module.exports = (nextConfig = {}) => ({
   ...nextConfig,
   exportPathMap: exportSw(nextConfig),
-  webpack(config, options) {
+  async webpack(config, options) {
     if (!options.defaultLoaders) {
       throw new Error(
         'This plugin is not compatible with Next.js versions below 5.0.0 https://err.sh/next-plugins/upgrade',


### PR DESCRIPTION
In the process of investigating https://github.com/hanford/next-offline/issues/69, I made a [reproduction repo](https://github.com/shawninder/next-manifest-sw-clash) which would call `next build` and then read the produced files to validate stuff. Strangely, the files didn't exist yet; somehow `next.build` was resolving before the files had been written.

This PR fixes that issue. Now, the files I expect to exist as soon as next.build resolves (including main.js) always do indeed exist.

What it means for my own reproduction repo is that now the tests match the manual repro.