### PR TITLE
Fix Tapable.plugin warning and supports assetPrefix in register-sw

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ tests/.next
 *.log
 tests/node_modules
 tests/static/manifest/
+register-sw-compiled.js

--- a/index.js
+++ b/index.js
@@ -2,6 +2,7 @@ const { GenerateSW, InjectManifest } = require('workbox-webpack-plugin');
 const CleanWebpackPlugin = require('clean-webpack-plugin');
 const CopyWebpackPlugin = require('copy-webpack-plugin');
 const { join } = require('path');
+const fs = require('fs');
 
 const InlineNextPrecacheManifestPlugin = require('./plugin');
 const exportSw = require('./export');
@@ -21,6 +22,7 @@ module.exports = (nextConfig = {}) => ({
       generateSw = true,
       dontAutoRegisterSw = false,
       devSwSrc = join(__dirname, 'service-worker.js'),
+      registerSwPrefix = assetPrefix || '',
       workboxOpts = {
         globPatterns: ['static/**/*'],
         globDirectory: '.',
@@ -50,7 +52,15 @@ module.exports = (nextConfig = {}) => ({
     config.entry = async () => {
       const entries = await originalEntry();
       if (entries['main.js'] && !dontAutoRegisterSw) {
-        entries['main.js'].unshift(require.resolve('./register-sw.js'));
+        let content = fs.readFileSync(require.resolve('./register-sw.js'), 'utf8');
+        content = content.replace('{REGISTER_SW_PREFIX}', registerSwPrefix);
+
+        fs.writeFileSync(join(__dirname, 'register-sw-compiled.js'), content, {
+          encoding: 'utf8',
+          flag: 'w',
+        });
+
+        entries['main.js'].unshift(require.resolve('./register-sw-compiled.js'));
       }
       return entries;
     };

--- a/index.js
+++ b/index.js
@@ -2,7 +2,7 @@ const { GenerateSW, InjectManifest } = require('workbox-webpack-plugin');
 const CleanWebpackPlugin = require('clean-webpack-plugin');
 const CopyWebpackPlugin = require('copy-webpack-plugin');
 const { join } = require('path');
-const fs = require('fs');
+const { readFile, writeFile } = require('fs-extra');
 
 const InlineNextPrecacheManifestPlugin = require('./plugin');
 const exportSw = require('./export');
@@ -52,13 +52,10 @@ module.exports = (nextConfig = {}) => ({
     config.entry = async () => {
       const entries = await originalEntry();
       if (entries['main.js'] && !dontAutoRegisterSw) {
-        let content = fs.readFileSync(require.resolve('./register-sw.js'), 'utf8');
+        let content = await readFile(require.resolve('./register-sw.js'), 'utf8');
         content = content.replace('{REGISTER_SW_PREFIX}', registerSwPrefix);
 
-        fs.writeFileSync(join(__dirname, 'register-sw-compiled.js'), content, {
-          encoding: 'utf8',
-          flag: 'w',
-        });
+        await writeFile(join(__dirname, 'register-sw-compiled.js'), content, 'utf8');
 
         entries['main.js'].unshift(require.resolve('./register-sw-compiled.js'));
       }

--- a/plugin.js
+++ b/plugin.js
@@ -6,14 +6,26 @@ module.exports = class InlineNextPrecacheManifestPlugin {
   }
 
   apply(compiler) {
-    compiler.plugin(
-      'done',
-      async () => {
-        await generateNextManifest(this.opts);
-      },
-      err => {
-        throw new Error(`Precached failed: ${err.toString()}`);
-      },
-    );
+    if (compiler.hooks) {
+      compiler.hooks.done.tap(
+        'CopyPlugin',
+        async () => {
+          await generateNextManifest(this.opts);
+        },
+        err => {
+          throw new Error(`Precached failed: ${err.toString()}`);
+        },
+      );
+    } else {
+      compiler.plugin(
+        'done',
+        async () => {
+          await generateNextManifest(this.opts);
+        },
+        err => {
+          throw new Error(`Precached failed: ${err.toString()}`);
+        },
+      );
+    }
   }
 };

--- a/plugin.js
+++ b/plugin.js
@@ -6,25 +6,21 @@ module.exports = class InlineNextPrecacheManifestPlugin {
   }
 
   apply(compiler) {
+    const errorhandler = err => {
+      throw new Error(`Precached failed: ${err.toString()}`);
+    };
+
     if (compiler.hooks) {
       compiler.hooks.done.tap(
         'CopyPlugin',
-        async () => {
-          await generateNextManifest(this.opts);
-        },
-        err => {
-          throw new Error(`Precached failed: ${err.toString()}`);
-        },
+        async() => generateNextManifest(this.opts),
+        errorhandler
       );
     } else {
       compiler.plugin(
         'done',
-        async () => {
-          await generateNextManifest(this.opts);
-        },
-        err => {
-          throw new Error(`Precached failed: ${err.toString()}`);
-        },
+        async() => generateNextManifest(this.opts),
+        errorhandler
       );
     }
   }

--- a/register-sw.js
+++ b/register-sw.js
@@ -1,7 +1,7 @@
 if ('serviceWorker' in navigator) {
   window.addEventListener('load', function() {
     navigator.serviceWorker
-      .register('/service-worker.js')
+      .register('{REGISTER_SW_PREFIX}/service-worker.js')
       .then(function(registration) {
         console.log('SW registered: ', registration);
       })


### PR DESCRIPTION
# What's new

- `compiler.plugin(...)` is deprecated and gives a warning during the next.js build; added in  `compiler.hooks.done` as it's the suggested syntax. 
- Add `assetPrefix` supports has if you are fetching your assets from a CDN or virtual directory `register-sw.js` will always use the root folder to get the service-worker. With this fix will take either `assetPrefix` (if specified) or `registerSwPrefix` (in case we want to overwrite `assetPrefix` value)