### PR TITLE
Pass `verbose: false` to CleanWebpackPlugin, closes #85

### DIFF
--- a/index.js
+++ b/index.js
@@ -37,7 +37,7 @@ module.exports = (nextConfig = {}) => ({
     } else if (!options.isServer) {
       // Only run once for the client build.
       config.plugins.push(
-        new CleanWebpackPlugin(['precache-manifest.*.js'], { root: config.output.path }),
+        new CleanWebpackPlugin(['precache-manifest.*.js'], { root: config.output.path, verbose: false }),
         generateSw ? new GenerateSW({ ...workboxOpts }) : new InjectManifest({ ...workboxOpts }),
         new InlineNextPrecacheManifestPlugin({
           outputPath: config.output.path,


### PR DESCRIPTION
# Overview

In the event that @hanford agrees that since what is described in #85 is expected behavior, this PR just adds an additional config property to disable that log, per `clean-webpack-plugin`'s available options: https://github.com/johnagan/clean-webpack-plugin#options-and-defaults-optional.