### PR TITLE
Huaoe patch 1

### DIFF
--- a/next-manifest.js
+++ b/next-manifest.js
@@ -45,7 +45,7 @@ function getOriginalManifest(manifestFilePath) {
 
 function buildNextManifest(originalManifest, urlPrefix = '') {
   return originalManifest.filter(entry => !excludeFiles.includes(entry.url)).map(entry => ({
-    url: `${urlPrefix}${nextUrlPrefix}${entry.url}`,
+    url: `${urlPrefix}${nextUrlPrefix}${entry.url.replace(/\\/g, '\/')}`,
   }));
 }
 

--- a/next-manifest.js
+++ b/next-manifest.js
@@ -45,7 +45,7 @@ function getOriginalManifest(manifestFilePath) {
 
 function buildNextManifest(originalManifest, urlPrefix = '') {
   return originalManifest.filter(entry => !excludeFiles.includes(entry.url)).map(entry => ({
-    url: `${urlPrefix}${nextUrlPrefix}${entry.url.replace(/\\/g, '\/')}`,
+    url: `${urlPrefix}${nextUrlPrefix}`+entry.url.replace(/\\/g, '/'),
   }));
 }
 


### PR DESCRIPTION
modifying function buildNextManifest to replace backslash with simpleslash

function buildNextManifest(originalManifest, urlPrefix = '') {
return originalManifest.filter(entry => !excludeFiles.includes(entry.url)).map(entry => ({
url: ${urlPrefix}${nextUrlPrefix}+entry.url.replace(/\/g, '/')
}));
}

fixing issue hanford#84