### PR TITLE
Docs Default workboxOpts key fix

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -94,7 +94,7 @@ By default `next-offline` has the following blanket runtime caching strategy. If
 {
   globPatterns: ['static/**/*'],
   globDirectory: '.',
-  { urlPattern: /^https?.*/, handler: 'networkFirst' }
+  runtimeCaching: { urlPattern: /^https?.*/, handler: 'networkFirst' }
 }
 ```
 


### PR DESCRIPTION
Adds the required `runtimeCaching` key to the object value in the explanation of what the default `workboxOpts` are.

# 🎉 Thanks for taking the time to contribute to next-offline

It is highly appreciated that you take the time to help improve next-offline.
We appreciate it if you would take the time to document your Pull Request.

Sadly, if we don't receive enough information, or the Pull Request doesn't
align well with our roadmap, we might respectfully
thank you for your time, and close the issue.

## Respect earns Respect 👏

Please respect our Code of Conduct, in short:

- Using welcoming and inclusive language.
- Being respectful of differing viewpoints and experiences.
- Gracefully accepting constructive criticism.
- Focusing on what is best for the community.
- Showing empathy towards other community members.