### PR TITLE
Support absolute paths in configuration

### DIFF
--- a/next-manifest.js
+++ b/next-manifest.js
@@ -1,6 +1,6 @@
 const glob = require('glob');
 const { readFile, writeFile } = require('fs-extra');
-const { join } = require('path');
+const { resolve } = require('path');
 
 const nextUrlPrefix = '/_next/';
 const excludeFiles = ['react-loadable-manifest.json', 'build-manifest.json'];
@@ -17,8 +17,8 @@ const manifestImportRegex = /(,\s*(\r\n|\r|\n)\s*)?"precache-manifest\.[^.]*\.js
  * At the end replace old manifest reference with new inlined one.
  */
 async function generateNextManifest(options) {
-  const manifestFilePath = join(options.outputPath, manifestDest);
-  const swFilePath = join(options.outputPath, options.swDest);
+  const manifestFilePath = resolve(options.outputPath, manifestDest);
+  const swFilePath = resolve(options.outputPath, options.swDest);
 
   const originalManifest = await getOriginalManifest(manifestFilePath);
   const nextManifest = buildNextManifest(originalManifest, options.urlPrefix);


### PR DESCRIPTION
Related: #94 

Currently the paths in the `exportSw` function are joined with `path.join`. This works really great if the configuration does not contains multiple absolute paths, since the function does not normalize paths. For this reason this PR changes the behavior to use `path.resolve`(which does normalize the path) instead.

The REPL session below showcases the different in behavior(The lines showing the combintation of `rootPath` and `swPath2` are of primary interest):

```js
> var rootPath = "/home/patrick/Development/helios/git/.build";
> var swPath1 = "./service-worker.js";
> var swPath2 = rootPath + "/service-worker.js";
> path.join(rootPath, swPath1)
'/home/patrick/Development/helios/git/.build/service-worker.js'
> path.resolve(rootPath, swPath1)
'/home/patrick/Development/helios/git/.build/service-worker.js'
> path.join(rootPath, swPath2)
'/home/patrick/Development/helios/git/.build/home/patrick/Development/helios/git/.build/service-worker.js'
> path.resolve(rootPath, swPath2)
'/home/patrick/Development/helios/git/.build/service-worker.js'
> path.join(swPath1)
'service-worker.js'
> path.resolve(swPath1)
'/home/patrick/service-worker.js'
> path.join(swPath2)
'/home/patrick/Development/helios/git/.build/service-worker.js'
> path.resolve(swPath2)
'/home/patrick/Development/helios/git/.build/service-worker.js'
```

Please tell me what you think of this change. This would simplify my configuration a bit, but I can imagine how the current behavior might be intended.
