### PR TITLE
Fix webpackHotUpdate is not defined error

### DIFF
--- a/index.js
+++ b/index.js
@@ -56,14 +56,20 @@ module.exports = (nextConfig = {}) => ({
       const originalEntry = config.entry;
       config.entry = async () => {
         const entries = await originalEntry();
-        if (entries['main.js'] && !dontAutoRegisterSw) {
+        const swCompiledPath = join(__dirname, 'register-sw-compiled.js')
+        // See https://github.com/zeit/next.js/blob/canary/examples/with-polyfills/next.config.js for a reference on how to add new entrypoints
+        if (
+          entries['main.js'] &&
+          !entries['main.js'].includes(swCompiledPath) &&
+          !dontAutoRegisterSw
+        ) {
           let content = await readFile(require.resolve('./register-sw.js'), 'utf8');
           content = content.replace('{REGISTER_SW_PREFIX}', registerSwPrefix);
           content = content.replace('{SW_SCOPE}', scope);
-  
-          await writeFile(join(__dirname, 'register-sw-compiled.js'), content, 'utf8');
-  
-          entries['main.js'].unshift(require.resolve('./register-sw-compiled.js'));
+
+          await writeFile(swCompiledPath, content, 'utf8');
+
+          entries['main.js'].unshift(swCompiledPath);
         }
         return entries;
       };

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "url": "https://github.com/hanford/next-offline.git"
   },
   "scripts": {
-    "test": "cd examples/tests && yarn test"
+    "test": "cd tests && yarn test"
   },
   "bugs": "https://github.com/hanford/next-offline/issues",
   "authors": [


### PR DESCRIPTION
First of all thanks for such nice project!

This PR addresses #121. When I try to use the `generateInDevMode: true` I see the error `webpackHotUpdate is not defined`.
I believe this happen because `register-sw-compiled.js` is added several times in the main.js entry. Checking if it is already there before adding it fixes the issue.
Looking at the next with-polyfill example thats how they handle it as well https://github.com/zeit/next.js/blob/canary/examples/with-polyfills/next.config.js#L9