### PR TITLE
Resolving manifestFilePath should consider workbox importsDirectory o…

### DIFF
--- a/index.js
+++ b/index.js
@@ -47,6 +47,7 @@ module.exports = (nextConfig = {}) => ({
           outputPath: config.output.path,
           urlPrefix: assetPrefix,
           swDest: workboxOpts.swDest || 'service-worker.js',
+          importsDirectory: workboxOpts.importsDirectory || '',
         }),
       );
     }

--- a/index.js
+++ b/index.js
@@ -47,7 +47,7 @@ module.exports = (nextConfig = {}) => ({
           outputPath: config.output.path,
           urlPrefix: assetPrefix,
           swDest: workboxOpts.swDest || 'service-worker.js',
-          importsDirectory: workboxOpts.importsDirectory || '',
+          importsDirectory: workboxOpts.importsDirectory || ''
         }),
       );
     }

--- a/next-manifest.js
+++ b/next-manifest.js
@@ -17,7 +17,7 @@ const manifestImportRegex = /(,\s*(\r\n|\r|\n)\s*)?"precache-manifest\.[^.]*\.js
  * At the end replace old manifest reference with new inlined one.
  */
 async function generateNextManifest(options) {
-  const manifestFilePath = resolve(options.outputPath, manifestDest);
+  const manifestFilePath = resolve(options.outputPath, options.importsDirectory, manifestDest);
   const swFilePath = resolve(options.outputPath, options.swDest);
 
   const originalManifest = await getOriginalManifest(manifestFilePath);


### PR DESCRIPTION
Trying to use adding the `importsDirectory` supported option from workbox-webpack-plugin results in an error

```
> NODE_ENV=production next build

[3:53:41 PM] Compiling client
[3:53:41 PM] Compiling server
> Using external babel configuration
> Location: "../babel.config.js"
[3:53:51 PM] Compiled client in 9s
(node:29575) UnhandledPromiseRejectionWarning: TypeError [ERR_INVALID_ARG_TYPE]: The "path" argument must be one of type string, Buffer, or URL. Received type undefined
    at readFile (fs.js:297:3)
    at go$readFile (../graceful-fs/graceful-fs.js:85:14)
    at readFile (../graceful-fs/graceful-fs.js:82:12)
    at Promise (../universalify/index.js:13:12)
    at new Promise (<anonymous>)
    at readFile (../universalify/index.js:7:14)
    at glob (../next-offline/next-manifest.js:36:26)
    at f (../once/once.js:25:25)
    at Glob.<anonymous> (../glob/glob.js:151:7)
    at Glob.emit (events.js:182:13)
    at Glob._finish (../glob/glob.js:197:8)
    at done (../glob/glob.js:182:14)
    at Glob._processReaddir2 (../glob/glob.js:408:12)
    at ../glob/glob.js:371:17
    at RES (../inflight/inflight.js:31:16)
    at f (../once/once.js:25:25)
    at Glob._readdirEntries (../glob/glob.js:578:10)
    at ../glob/glob.js:555:12
    at FSReqWrap.oncomplete (fs.js:141:20)

```

These proposed changes consider this option when trying to resolve the manifest file path