### PR TITLE
feat: add `transformManifest` to customise pre-caching

### DIFF
--- a/index.js
+++ b/index.js
@@ -25,6 +25,7 @@ module.exports = (nextConfig = {}) => ({
       registerSwPrefix = '',
       scope = '/',
       generateInDevMode = false,
+      transformManifest = manifest => manifest,
       workboxOpts = {
         globPatterns: ['static/**/*'],
         globDirectory: '.',
@@ -47,7 +48,8 @@ module.exports = (nextConfig = {}) => ({
           outputPath: config.output.path,
           urlPrefix: assetPrefix,
           swDest: workboxOpts.swDest || 'service-worker.js',
-          importsDirectory: workboxOpts.importsDirectory || ''
+          importsDirectory: workboxOpts.importsDirectory || '',
+          transformManifest
         }),
       );
     }

--- a/next-manifest.js
+++ b/next-manifest.js
@@ -22,7 +22,12 @@ async function generateNextManifest(options) {
 
   const originalManifest = await getOriginalManifest(manifestFilePath);
   const nextManifest = buildNextManifest(originalManifest, options.urlPrefix);
-  await inlineManifest(nextManifest, swFilePath);
+  if (options.transformManifest) {
+    const transformedManifest = options.transformManifest(nextManifest);
+    await inlineManifest(transformedManifest, swFilePath);
+  } else {
+    await inlineManifest(nextManifest, swFilePath);
+  }
 }
 
 function getOriginalManifest(manifestFilePath) {
@@ -46,6 +51,7 @@ function getOriginalManifest(manifestFilePath) {
 function buildNextManifest(originalManifest, urlPrefix = '') {
   return originalManifest.filter(entry => !excludeFiles.includes(entry.url)).map(entry => ({
     url: `${urlPrefix}${nextUrlPrefix}${entry.url}`,
+    revision: entry.revision
   }));
 }
 

--- a/readme.md
+++ b/readme.md
@@ -210,6 +210,12 @@ On top of the workbox options, next-offline has some options built in flags to g
       <td>This is passed to the automatically registered service worker allowing increase or decrease what the service worker has control of.</td>
       <td>"/"</td>
     </tr>
+    <tr>
+      <td>transformManifest</td>
+      <td>Function</td>
+      <td>This is passed the manifest, allowing you to customise the list of assets for the service worker to precache.</td>
+      <td>(manifest) => manifest</td>
+    </tr>
   </tbody>
 </table>
 


### PR DESCRIPTION
## Reason for pull request

When using `next-offline` together with `next export`, the .html files are not pre-cached.

## What this adds

a new option `transformManifest`, that allows you to provide a function to modify the manifest, and add/remove items which will be pre-cached.

For example, this allows me to pre-cache all HTML files generated by `next export`:

```js
// next.config.js

module.exports = nextOffline({
    transformManifest: manifest => {
        return manifest.reduce(
            (acc, item) => {
                const pageMatch = item.url.match(/\/_next\/static\/[^/]+\/pages\/([^_](?:.*?))\.js$/);
                if (pageMatch) {
                    acc.push({ url: `/${pageMatch[1]}.html`, revision: item.revision });
                }
                acc.push(item);
                return acc;
            },
            []
        );
    }
});
```