### PR TITLE
fix exportPathMap not called in dev mode

### DIFF
--- a/export.js
+++ b/export.js
@@ -7,12 +7,10 @@ function exportSw(nextConfig) {
     const [defaultPathMap, { dev, distDir, outDir }] = args;
     const swDest = (nextConfig.workboxOpts && nextConfig.workboxOpts.swDest) || 'service-worker.js';
 
-    if (dev) {
-      return defaultPathMap;
+    if (!dev) {
+      // Copy service worker from Next.js build dir into the export dir.
+      await copy(join(distDir, swDest), join(outDir, swDest));
     }
-
-    // Copy service worker from Next.js build dir into the export dir.
-    await copy(join(distDir, swDest), join(outDir, swDest));
 
     // Run user's exportPathMap function if available.
     return nextConfig.exportPathMap ? nextConfig.exportPathMap(...args) : defaultPathMap;


### PR DESCRIPTION
When running in dev mode `exportPathMap` should also be executed as this is the default behaviour in Next.js.