### PR TITLE
Update networkFirst to v4

### DIFF
--- a/examples/now2/next.config.js
+++ b/examples/now2/next.config.js
@@ -8,7 +8,7 @@ const nextConfig = {
     runtimeCaching: [
       {
         urlPattern: /^https?.*/,
-        handler: 'networkFirst',
+        handler: 'NetworkFirst',
         options: {
           cacheName: 'https-calls',
           networkTimeoutSeconds: 15,


### PR DESCRIPTION
Hello 👋

This prevents the warning "deprecated networkFirst" from example.

Updated according [migration guide](https://developers.google.com/web/tools/workbox/guides/migrations/migrate-from-v3).