### PR TITLE
Improve plugin async flow

### DIFF
--- a/plugin.js
+++ b/plugin.js
@@ -13,8 +13,7 @@ module.exports = class InlineNextPrecacheManifestPlugin {
     if (compiler.hooks) {
       compiler.hooks.done.tapPromise(
         'CopyPlugin',
-        async() => generateNextManifest(this.opts),
-        errorhandler
+        async() => generateNextManifest(this.opts).cactch(errorhandler)
       );
     } else {
       compiler.plugin(

--- a/plugin.js
+++ b/plugin.js
@@ -13,7 +13,7 @@ module.exports = class InlineNextPrecacheManifestPlugin {
     if (compiler.hooks) {
       compiler.hooks.done.tapPromise(
         'CopyPlugin',
-        async() => generateNextManifest(this.opts).cactch(errorhandler)
+        async() => generateNextManifest(this.opts).catch(errorhandler)
       );
     } else {
       compiler.plugin(

--- a/plugin.js
+++ b/plugin.js
@@ -11,7 +11,7 @@ module.exports = class InlineNextPrecacheManifestPlugin {
     };
 
     if (compiler.hooks) {
-      compiler.hooks.done.tap(
+      compiler.hooks.done.tapPromise(
         'CopyPlugin',
         async() => generateNextManifest(this.opts),
         errorhandler


### PR DESCRIPTION
`tapPromise` should be used instead of `tap`  properly handle `async` service worker file save.
`tap` is for sync plugins based on documentation. 

https://webpack.js.org/api/plugins/#plugin-types

Also looks like `tap*` doesn't have third argument for error handler.

https://github.com/webpack/tapable#hookhookmap-interface