### PR TITLE
Move webpack to peer dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,20 +51,21 @@
     "sw-helpers"
   ],
   "peerDependencies": {
-    "next": ">=7.0.0"
+    "next": ">=7.0.0",
+    "webpack": "^4.19.1"
   },
   "dependencies": {
     "clean-webpack-plugin": "^0.1.19",
     "copy-webpack-plugin": "~4.5.2",
     "fs-extra": "~7.0.0",
     "glob": "~7.1.3",
-    "webpack": "^4.19.1",
     "workbox-webpack-plugin": "^4.3.1"
   },
   "devDependencies": {
     "husky": "^0.14.3",
     "prettier": "^1.14.3",
-    "pretty-quick": "^1.7.0"
+    "pretty-quick": "^1.7.0",
+    "webpack": "^4.19.1"
   },
   "husky": {
     "hooks": {


### PR DESCRIPTION
It looks like webpack can be peer dependence.

Code itself does not use it from what I can see.