### PR TITLE
Fix ValidationError: "generateInDevMode" is not a supported parameter on example

### DIFF
--- a/packages/now2-example/next.config.js
+++ b/packages/now2-example/next.config.js
@@ -3,10 +3,10 @@ const withOffline = require('next-offline');
 const nextConfig = {
   target: 'serverless',
   transformManifest: manifest => ['/'].concat(manifest), // add the homepage to the cache
+  // Trying to set NODE_ENV=production when running yarn dev causes a build-time error so we
+  // turn on the SW in dev mode so that we can actually test it
+  generateInDevMode: true,
   workboxOpts: {
-    // Trying to set NODE_ENV=production when running yarn dev causes a build-time error so we
-    // turn on the SW in dev mode so that we can actually test it
-    generateInDevMode: true,
     swDest: 'static/service-worker.js',
     runtimeCaching: [
       {


### PR DESCRIPTION
It's being accessed from nextconfig: https://github.com/hanford/next-offline/blob/master/packages/next-offline/index.js#L57