### PR TITLE
Fix passing unsupported params into InjectManifest plugin

### DIFF
--- a/packages/next-offline/index.js
+++ b/packages/next-offline/index.js
@@ -18,15 +18,19 @@ const nextAssetDirectory = 'static';
 // The URL path prefix for all static assets contained within a Next project
 const nextAssetLinkPrefix = '_next/static/';
 
-const defaultWorkboxOpts = {
+const defaultInjectOpts = {
   exclude: preCacheManifestBlacklist,
+  modifyURLPrefix: {
+    'static/': nextAssetLinkPrefix,
+  },
+}
+
+const defaultGenerateOpts = {
+  ...defaultInjectOpts,
   // As of Workbox v5 Alpha there isn't a well documented way to move workbox runtime into the directory
   // required by Next. As a work around, we inline the tree-shaken runtime into the main Service Worker file
   // at the cost of less cacheability
   inlineWorkboxRuntime: true,
-  modifyURLPrefix: {
-    'static/': nextAssetLinkPrefix,
-  },
   runtimeCaching: [
     {
       urlPattern: /^https?.*/,
@@ -63,7 +67,6 @@ module.exports = (nextConfig = {}) => ({
       workboxOpts = {},
     } = nextConfig;
 
-    const combinedWorkboxOpts = { ...defaultWorkboxOpts, ...workboxOpts };
     const skipDuringDevelopment = options.dev && !generateInDevMode;
 
     // Generate SW
@@ -76,7 +79,7 @@ module.exports = (nextConfig = {}) => ({
         // Workbox uses Webpack's asset manifest to generate the SW's pre-cache manifest, so we need
         // to copy the app's assets into the Webpack context so those are picked up.
         new CopyWebpackPlugin([{ from: `${join(cwd(), nextAssetDirectory)}/**/*` }]),
-        generateSw ? new GenerateSW({ ...combinedWorkboxOpts }) : new InjectManifest({ ...combinedWorkboxOpts }),
+        generateSw ? new GenerateSW({ ...defaultGenerateOpts, ...workboxOpts }) : new InjectManifest({ ...defaultInjectOpts, ...workboxOpts }),
       );
     }
 


### PR DESCRIPTION
Fixes #175. Workbox crashes during the build if it receives unsupported parameters, so splitting the defaults into 2 variables fixes that.

`"inlineWorkboxRuntime" is not a supported parameter.. "runtimeCaching" is not a supported parameter.`