### PR TITLE
run generation when workbox-webpack-plugin finished

### DIFF
--- a/plugin.js
+++ b/plugin.js
@@ -11,16 +11,11 @@ module.exports = class InlineNextPrecacheManifestPlugin {
     };
 
     if (compiler.hooks) {
-      compiler.hooks.done.tapPromise(
-        'CopyPlugin',
-        async() => generateNextManifest(this.opts).catch(errorhandler)
+      compiler.hooks.done.tapPromise('GenerateSW', () =>
+        generateNextManifest(this.opts).catch(errorhandler),
       );
     } else {
-      compiler.plugin(
-        'done',
-        async() => generateNextManifest(this.opts),
-        errorhandler
-      );
+      compiler.plugin('done', () => generateNextManifest(this.opts), errorhandler);
     }
   }
 };


### PR DESCRIPTION
Resolves #183

For some reason, there was a hook on `CopyPlugin` which in many cases may be invalid, as `CopyPlugin` can be used in many places. To ensure that `workbox-webpack-plugin` finished its work, we can hook up on `GenerateSW`.