### PR TITLE
Update now.json in now2 example

### DIFF
--- a/packages/now2-example/now.json
+++ b/packages/now2-example/now.json
@@ -1,19 +1,24 @@
 {
   "version": 2,
-  "routes": [
+  "rewrites": [
     {
-      "src": "^/service-worker.js$",
-      "dest": "/_next/static/service-worker.js",
-      "headers": {
-        "cache-control": "public, max-age=43200, immutable",
-        "Service-Worker-Allowed": "/"
-      }
+      "source": "/service-worker.js",
+      "destination": "/_next/static/service-worker.js"
     }
   ],
-  "builds": [
+  "headers": [
     {
-      "src": "next.config.js",
-      "use": "@now/next"
+      "source": "/service-worker.js",
+      "headers": [
+        {
+          "key": "Cache-Control",
+          "value": "public, max-age=43200, immutable"
+        },
+        {
+          "key": "Service-Worker-Allowed",
+          "value": "/"
+        }
+      ]
     }
   ]
 }


### PR DESCRIPTION
Hi all!

Thanks for creating this plugin, it did help me creating the COVID-19 [Costa Rica status page](https://covid19cr.com).

This PR just modifies the contents of `now.json` file of the Now2 example, removing the `builds` and `routes` config option since they are being deprecated and adds `rewrites` and `headers` options.

Closes #211 