### PR TITLE
docs: Update readme.md to correct the workbox option

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -278,7 +278,7 @@ If you'd like to include some more or change the origin of your static files use
 
 ```js
 workboxOpts: {
-  modifyUrlPrefix: {
+  modifyURLPrefix: {
     'app': assetPrefix,
   },
   runtimeCaching: {...}


### PR DESCRIPTION
This option is incorrectly specified in the README. It should be `modifyURLPrefix` according to the Workbox docs. 
https://developers.google.com/web/tools/workbox/reference-docs/latest/module-workbox-webpack-plugin.GenerateSW

![image](https://user-images.githubusercontent.com/1635852/79619505-b5372900-80d2-11ea-863e-ef849f03372e.png)
