### PR TITLE
feat: allow passing scope for runtime registration

### DIFF
--- a/packages/next-offline/runtime.js
+++ b/packages/next-offline/runtime.js
@@ -6,10 +6,10 @@ function unregister() {
   }
 }
 
-function register(swPath) {
+function register(swPath, options) {
   if ('serviceWorker' in navigator) {
     navigator.serviceWorker
-      .register(swPath || '/service-worker.js')
+      .register(swPath || '/service-worker.js', options)
       .then(function(registration) {
         console.log('SW registered: ', registration);
       })

--- a/readme.md
+++ b/readme.md
@@ -147,7 +147,7 @@ import { register, unregister } from 'next-offline/runtime'
 class App extends React.Component {
   componentDidMount () {
     /** 
-      *  Default service worker path is '/service-worker.js' 
+      * Default service worker path is '/service-worker.js' 
       * Refer https://developer.mozilla.org/en-US/docs/Web/API/ServiceWorkerContainer/register for default scope rules
       *
     */

--- a/readme.md
+++ b/readme.md
@@ -140,6 +140,28 @@ class App extends React.Component {
 }
 ```
 
+You can choose to pass the service worker path and scope if needed. 
+```js
+import { register, unregister } from 'next-offline/runtime'
+
+class App extends React.Component {
+  componentDidMount () {
+    /** 
+      *  Default service worker path is '/service-worker.js' 
+      * Refer https://developer.mozilla.org/en-US/docs/Web/API/ServiceWorkerContainer/register for default scope rules
+      *
+    */
+    register('/sub_folder/service-worker.js', {scope: '/sub_folder'}) 
+  }
+  componentWillUnmount () {
+    unregister()
+  }
+  ..
+}
+```
+https://developer.mozilla.org/en-US/docs/Web/API/ServiceWorkerContainer/register
+
+
 If you're handling registration on your own, pass `dontAutoRegisterSw` to next-offline.
 ```js
 // next.config.js

--- a/readme.md
+++ b/readme.md
@@ -159,8 +159,6 @@ class App extends React.Component {
   ..
 }
 ```
-https://developer.mozilla.org/en-US/docs/Web/API/ServiceWorkerContainer/register
-
 
 If you're handling registration on your own, pass `dontAutoRegisterSw` to next-offline.
 ```js


### PR DESCRIPTION
Closes https://github.com/hanford/next-offline/issues/239

The issue https://github.com/hanford/next-offline/issues/239 is probably invalid but this PR should still help people who want to limit the scope of service worker on runtime registration. 

@hanford 
Let me know if you see any issues with this. 